### PR TITLE
Update dependabot.yml to assign balen to PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
     time: "10:00"
   open-pull-requests-limit: 10
   assignees:
+      - "balen"
   ignore:
   - dependency-name: rubocop
     versions:


### PR DESCRIPTION
I have been automatically assigned the dependabot PRs for quite some time and I'm not sure why. These PR notifications are always showing up in my email, so I made this change to try and ensure that the PRs are assigned to balen and not to me by default.

The following documentation explains the assignees in the dependabot.yml.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#assignees